### PR TITLE
ComputerVision remove non-nullable scalars

### DIFF
--- a/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/ComputerVision.json
+++ b/specification/cognitiveservices/data-plane/ComputerVision/stable/v2.0/ComputerVision.json
@@ -901,6 +901,7 @@
         "textAngle": {
           "type": "number",
           "format": "double",
+          "x-nullable": false,
           "description": "The angle, in degrees, of the detected text with respect to the closest horizontal or vertical direction. After rotating the input image clockwise by this angle, the recognized text lines become horizontal or vertical. In combination with the orientation property it can be used to overlay recognition results correctly on the original image, by rotating either the original image or recognition results by a suitable angle around the center of the original image. If the angle cannot be confidently detected, this property is not present. If the image contains text at different angles, only part of the text will be recognized correctly."
         },
         "orientation": {
@@ -1116,6 +1117,7 @@
         "confidence": {
           "type": "number",
           "format": "double",
+          "x-nullable": false,
           "description": "The level of confidence the service has in the caption"
         }
       }
@@ -1131,6 +1133,7 @@
         "confidence": {
           "type": "number",
           "format": "double",
+          "x-nullable": false,
           "description": "The level of confidence the service has in the caption"
         },
         "hint": {
@@ -1146,11 +1149,13 @@
         "width": {
           "type": "integer",
           "format": "int32",
+          "x-nullable": false,
           "description": "Image width"
         },
         "height": {
           "type": "integer",
           "format": "int32",
+          "x-nullable": false,
           "description": "Image height"
         },
         "format": {
@@ -1170,6 +1175,7 @@
         "confidence": {
           "type": "number",
           "format": "double",
+          "x-nullable": false,
           "description": "Level of confidence ranging from 0 to 1."
         },
         "faceRectangle": {
@@ -1188,6 +1194,7 @@
         "confidence": {
           "type": "number",
           "format": "double",
+          "x-nullable": false,
           "description": "Confidence level for the landmark recognition."
         }
       }
@@ -1198,18 +1205,22 @@
       "properties": {
         "left": {
           "type": "integer",
+          "x-nullable": false,
           "description": "X-coordinate of the top left point of the face."
         },
         "top": {
           "type": "integer",
+          "x-nullable": false,
           "description": "Y-coordinate of the top left point of the face."
         },
         "width": {
           "type": "integer",
+          "x-nullable": false,
           "description": "Width measured from the top-left point of the face."
         },
         "height": {
           "type": "integer",
+          "x-nullable": false,
           "description": "Height measured from the top-left point of the face."
         }
       }
@@ -1220,6 +1231,7 @@
       "properties": {
         "age": {
           "type": "integer",
+          "x-nullable": false,
           "description": "Possible age of the face."
         },
         "gender": {
@@ -1245,10 +1257,12 @@
       "properties": {
         "clipArtType": {
           "type": "number",
+          "x-nullable": false,
           "description": "Confidence level that the image is a clip art."
         },
         "lineDrawingType": {
           "type": "number",
+          "x-nullable": false,
           "description": "Confidence level that the image is a line drawing."
         }
       }
@@ -1321,6 +1335,7 @@
         "score": {
           "type": "number",
           "format": "double",
+          "x-nullable": false,
           "description": "Scoring of the category."
         },
         "detail": {


### PR DESCRIPTION
Generally the objects may be unspecified, but when specified, the scalars
contained within them, such as confidence scores, are present.

While this is a breaking change w/r/t to v1.0 of the Azure-named SDK, it is
actually an un-breaking change for our customers who have been using the
hand-crafted [SDK](https://github.com/microsoft/cognitive-vision-windows), which
has been the official SDK up to now.

This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.

### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).

### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] The spec follows the guidelines described in the [Swagger checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md) document.
  - [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
